### PR TITLE
feat: add research category for LLM knowledge base

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md - LLM Agent Instructions
+
+## Project Overview
+
+HonoX blog + research knowledge base framework deployed to Cloudflare Workers.
+Published as `@karukan029/dev` npm package. Content lives in consuming repos (e.g., dev-blog).
+
+## Tech Stack
+
+- Framework: HonoX (Hono meta-framework)
+- Build: Vite + Wrangler
+- Deploy: Cloudflare Workers
+- Styling: Tailwind CSS v4
+- Language: TypeScript (strict mode)
+- Linter/Formatter: Biome (`pnpm check`, `pnpm check:fix`)
+- Package Manager: pnpm
+
+## Content Locations
+
+- Blog posts: `contents/posts/` (or consumer repo's `postsDir`)
+- Research raw sources: `contents/research/raw/`
+- Research wiki: `contents/research/wiki/`
+- Config: `dev.config.ts` (sections.research.dir for wiki path)
+
+## Research Wiki Operations
+
+### Frontmatter Schema
+
+```yaml
+---
+title: "Article Title"
+category: "category-name"
+tags: ["tag1", "tag2"]
+sources: ["raw/source-dir-name"]
+related: ["other-wiki-slug"]
+created: "YYYY-MM-DD"
+updated: "YYYY-MM-DD"
+status: "draft" | "review" | "stable"
+---
+```
+
+### Compiling Raw -> Wiki
+
+1. Read all files in the specified `raw/<source>/` directory
+2. Create or update a wiki article in `wiki/<topic>.md`
+3. Use the frontmatter schema above
+4. Set status to "draft" for new articles
+5. Add cross-references via `related` field
+6. Update `wiki/_index.md` after any article creation/deletion
+
+### Updating the Index (`wiki/_index.md`)
+
+Use `lib/research/index-generator.ts`:
+- Scans all `.md` files in `wiki/` (excluding `_index.md`)
+- Groups by `category` frontmatter field
+- Lists each article with title, status, and tags
+- Includes a "Recently Updated" section (top 10 by `updated` date)
+
+### Linting the Wiki
+
+Use `lib/research/linter.ts`. Checks for:
+- Broken related links (references to non-existent wiki slugs)
+- Missing required frontmatter fields (title, category, status, created, updated)
+- Orphan articles (not linked from any other article)
+- Missing backlinks (A links to B, but B doesn't list A in `related`)
+- Raw sources with no corresponding wiki article
+- Stale drafts (not updated in 30+ days)
+
+### Q&A Mode
+
+When asked a question about the wiki:
+1. Read `wiki/_index.md` for overview
+2. Read relevant wiki articles (use tags/categories to narrow scope)
+3. If needed, read raw sources for deeper detail
+4. Answer with citations in the form `[source: wiki/topic-name]`
+5. If the answer reveals a gap, suggest a new wiki article
+
+### Output Generation
+
+- Reports go to `wiki/` with category "report"
+- Use standard markdown
+
+## Code Conventions
+
+- TypeScript strict mode, ESNext target
+- Biome for formatting and linting (run `pnpm check` before committing)
+- HonoX route pattern: `createRoute(async (c) => { ... })`
+- SSG params in `_middleware.ts` files
+- Imports use `@dev-config` alias for config
+- Do not modify `contents/posts/` without explicit user request

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,42 +1,75 @@
 import devConfig from "@dev-config";
 import { createRoute } from "honox/factory";
-import { getPostListMarkdownEntries } from "../../lib/content/markdown";
+import {
+	getMarkdownEntries,
+	getPostListMarkdownEntries,
+} from "../../lib/content/markdown";
 import Counter from "../islands/counter";
 
 export default createRoute(async (c) => {
-  const name = c.req.query("name") ?? "Hono";
-  const entries = import.meta.env.PROD
-    ? getPostListMarkdownEntries().filter((entry) => entry.private !== true)
-    : getPostListMarkdownEntries();
+	const name = c.req.query("name") ?? "Hono";
+	const entries = import.meta.env.PROD
+		? getPostListMarkdownEntries().filter((entry) => entry.private !== true)
+		: getPostListMarkdownEntries();
 
-  if (entries.length === 0) {
-    return c.render(
-      <div class="py-8 text-center">
-        <title>{name}</title>
-        <h1 class="text-3xl font-bold">Hello, {name}!</h1>
-        <p class="text-gray-500">
-          No markdown files found under {devConfig.postsDir}.
-        </p>
-        <Counter />
-      </div>,
-    );
-  }
+	const researchDir =
+		devConfig.sections?.research?.dir ?? "contents/research/wiki";
+	const researchEntries = import.meta.env.PROD
+		? getMarkdownEntries(researchDir).filter((entry) => entry.private !== true)
+		: getMarkdownEntries(researchDir);
 
-  return c.render(
-    <div class="py-8 text-center space-y-6">
-      <h1>Posts</h1>
-      <div>
-        {entries.map((entry) => (
-          <div key={entry.slug}>
-            <a
-              href={`/posts/${entry.slug}`}
-              class="text-blue-600 hover:underline text-xl"
-            >
-              {entry.title ?? entry.slug}
-            </a>
-          </div>
-        ))}
-      </div>
-    </div>,
-  );
+	if (entries.length === 0 && researchEntries.length === 0) {
+		return c.render(
+			<div class="py-8 text-center">
+				<title>{name}</title>
+				<h1 class="text-3xl font-bold">Hello, {name}!</h1>
+				<p class="text-gray-500">
+					No markdown files found under {devConfig.postsDir}.
+				</p>
+				<Counter />
+			</div>,
+		);
+	}
+
+	return c.render(
+		<div class="py-8 text-center space-y-6">
+			{entries.length > 0 && (
+				<div>
+					<h1>Posts</h1>
+					<div>
+						{entries.map((entry) => (
+							<div key={entry.slug}>
+								<a
+									href={`/posts/${entry.slug}`}
+									class="text-blue-600 hover:underline text-xl"
+								>
+									{entry.title ?? entry.slug}
+								</a>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+			{researchEntries.length > 0 && (
+				<div>
+					<h2 class="text-2xl font-bold">Research</h2>
+					<div>
+						{researchEntries.map((entry) => (
+							<div key={entry.slug}>
+								<a
+									href={`/research/${entry.slug}`}
+									class="text-blue-600 hover:underline text-xl"
+								>
+									{entry.title ?? entry.slug}
+								</a>
+							</div>
+						))}
+					</div>
+					<a href="/research" class="text-gray-500 hover:underline text-sm">
+						View all research articles
+					</a>
+				</div>
+			)}
+		</div>,
+	);
 });

--- a/app/routes/posts/[slug].tsx
+++ b/app/routes/posts/[slug].tsx
@@ -2,30 +2,30 @@ import { createRoute } from "honox/factory";
 import { renderMarkdownBySlug } from "../../../lib/content/markdown";
 
 export default createRoute(async (c) => {
-  // Render markdown directly for SSG
-  const rendered = await renderMarkdownBySlug(c.req.param("slug"));
+	// Render markdown directly for SSG
+	const rendered = await renderMarkdownBySlug(c.req.param("slug"));
 
-  if (!rendered) {
-    return c.notFound();
-  }
+	if (!rendered) {
+		return c.notFound();
+	}
 
-  if (import.meta.env.PROD && rendered.frontmatter?.private) {
-    return c.notFound();
-  }
+	if (import.meta.env.PROD && rendered.frontmatter?.private) {
+		return c.notFound();
+	}
 
-  return c.render(
-    <article class="container mx-auto py-8 px-4 max-w-4xl">
-      {rendered.frontmatter?.title && (
-        <h1 class="text-5xl font-bold mb-8">{rendered.frontmatter.title}</h1>
-      )}
-      {rendered.frontmatter?.description && (
-        <p class="mb-7">{rendered.frontmatter.description}</p>
-      )}
-      <div
-        dangerouslySetInnerHTML={{
-          __html: rendered.html,
-        }}
-      />
-    </article>,
-  );
+	return c.render(
+		<article class="container mx-auto py-8 px-4 max-w-4xl">
+			{rendered.frontmatter?.title && (
+				<h1 class="text-5xl font-bold mb-8">{rendered.frontmatter.title}</h1>
+			)}
+			{rendered.frontmatter?.description && (
+				<p class="mb-7">{rendered.frontmatter.description}</p>
+			)}
+			<div
+				dangerouslySetInnerHTML={{
+					__html: rendered.html,
+				}}
+			/>
+		</article>,
+	);
 });

--- a/app/routes/research/[slug].tsx
+++ b/app/routes/research/[slug].tsx
@@ -1,0 +1,87 @@
+import devConfig from "@dev-config";
+import { createRoute } from "honox/factory";
+import { renderMarkdownFromDir } from "../../../lib/content/markdown";
+
+const researchDir =
+	devConfig.sections?.research?.dir ?? "contents/research/wiki";
+
+export default createRoute(async (c) => {
+	const rendered = await renderMarkdownFromDir(
+		researchDir,
+		c.req.param("slug"),
+	);
+
+	if (!rendered) {
+		return c.notFound();
+	}
+
+	if (import.meta.env.PROD && rendered.frontmatter?.private) {
+		return c.notFound();
+	}
+
+	const statusColors: Record<string, string> = {
+		draft: "bg-yellow-100 text-yellow-800",
+		review: "bg-blue-100 text-blue-800",
+		stable: "bg-green-100 text-green-800",
+	};
+	const status = rendered.status ?? "draft";
+	const statusClass = statusColors[status] ?? statusColors.draft;
+
+	return c.render(
+		<article class="container mx-auto py-8 px-4 max-w-4xl">
+			{rendered.frontmatter?.title && (
+				<h1 class="text-5xl font-bold mb-4">{rendered.frontmatter.title}</h1>
+			)}
+			<div class="flex flex-wrap gap-2 mb-6">
+				<span class={`px-2 py-1 rounded text-sm font-medium ${statusClass}`}>
+					{status}
+				</span>
+				{rendered.category && (
+					<span class="px-2 py-1 rounded text-sm bg-gray-100 text-gray-700">
+						{rendered.category}
+					</span>
+				)}
+				{rendered.tags?.map((tag) => (
+					<span
+						key={tag}
+						class="px-2 py-1 rounded text-sm bg-indigo-50 text-indigo-700"
+					>
+						{tag}
+					</span>
+				))}
+			</div>
+			<div
+				dangerouslySetInnerHTML={{
+					__html: rendered.html,
+				}}
+			/>
+			{rendered.related && rendered.related.length > 0 && (
+				<div class="mt-8 pt-6 border-t border-gray-200">
+					<h2 class="text-xl font-bold mb-3">Related Articles</h2>
+					<ul class="space-y-1">
+						{rendered.related.map((slug) => (
+							<li key={slug}>
+								<a
+									href={`/research/${slug}`}
+									class="text-blue-600 hover:underline"
+								>
+									{slug}
+								</a>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+			{rendered.sources && rendered.sources.length > 0 && (
+				<div class="mt-6 pt-4 border-t border-gray-200">
+					<h2 class="text-xl font-bold mb-3">Sources</h2>
+					<ul class="space-y-1 text-gray-600">
+						{rendered.sources.map((source) => (
+							<li key={source}>{source}</li>
+						))}
+					</ul>
+				</div>
+			)}
+		</article>,
+	);
+});

--- a/app/routes/research/_middleware.ts
+++ b/app/routes/research/_middleware.ts
@@ -1,0 +1,14 @@
+import devConfig from "@dev-config";
+import { ssgParams } from "hono/ssg";
+import { createRoute } from "honox/factory";
+import { getMarkdownEntries } from "../../../lib/content/markdown";
+
+const researchDir =
+	devConfig.sections?.research?.dir ?? "contents/research/wiki";
+
+export default createRoute(
+	ssgParams(async () => {
+		const entries = getMarkdownEntries(researchDir);
+		return entries.map((e) => ({ slug: e.slug }));
+	}),
+);

--- a/app/routes/research/index.tsx
+++ b/app/routes/research/index.tsx
@@ -1,0 +1,82 @@
+import devConfig from "@dev-config";
+import { createRoute } from "honox/factory";
+import {
+	getMarkdownEntries,
+	type MarkdownEntry,
+} from "../../../lib/content/markdown";
+
+const researchDir =
+	devConfig.sections?.research?.dir ?? "contents/research/wiki";
+
+export default createRoute(async (c) => {
+	const allEntries = getMarkdownEntries(researchDir);
+	const entries = import.meta.env.PROD
+		? allEntries.filter((entry) => entry.private !== true)
+		: allEntries;
+
+	if (entries.length === 0) {
+		return c.render(
+			<div class="py-8 text-center">
+				<h1 class="text-3xl font-bold">Research</h1>
+				<p class="text-gray-500 mt-4">No research articles found.</p>
+			</div>,
+		);
+	}
+
+	// Group entries by category
+	const grouped: Record<string, MarkdownEntry[]> = {};
+	for (const entry of entries) {
+		const cat = entry.category ?? "uncategorized";
+		if (!grouped[cat]) {
+			grouped[cat] = [];
+		}
+		grouped[cat].push(entry);
+	}
+
+	const statusColors: Record<string, string> = {
+		draft: "bg-yellow-100 text-yellow-800",
+		review: "bg-blue-100 text-blue-800",
+		stable: "bg-green-100 text-green-800",
+	};
+
+	return c.render(
+		<div class="container mx-auto py-8 px-4 max-w-4xl">
+			<h1 class="text-3xl font-bold mb-8">Research</h1>
+			{Object.entries(grouped).map(([category, categoryEntries]) => (
+				<div key={category} class="mb-8">
+					<h2 class="text-xl font-semibold mb-4 capitalize">{category}</h2>
+					<div class="space-y-3">
+						{categoryEntries.map((entry) => {
+							const status = entry.status ?? "draft";
+							const statusClass = statusColors[status] ?? statusColors.draft;
+
+							return (
+								<div key={entry.slug} class="flex items-center gap-3">
+									<a
+										href={`/research/${entry.slug}`}
+										class="text-blue-600 hover:underline text-lg"
+									>
+										{entry.title ?? entry.slug}
+									</a>
+									<span
+										class={`px-2 py-0.5 rounded text-xs font-medium ${statusClass}`}
+									>
+										{status}
+									</span>
+									{entry.tags?.map((tag) => (
+										<span
+											key={tag}
+											class="px-2 py-0.5 rounded text-xs bg-indigo-50 text-indigo-700"
+										>
+											{tag}
+										</span>
+									))}
+								</div>
+							);
+						})}
+					</div>
+				</div>
+			))}
+		</div>,
+	);
+});

--- a/app/routes/server/research/index.ts
+++ b/app/routes/server/research/index.ts
@@ -1,0 +1,31 @@
+import devConfig from "@dev-config";
+import { Hono } from "hono";
+import { renderMarkdownFromDir } from "../../../../lib/content/markdown";
+
+const researchDir =
+	devConfig.sections?.research?.dir ?? "contents/research/wiki";
+
+const app = new Hono();
+
+app.get("/:slug", async (c) => {
+	const slug = c.req.param("slug");
+	if (!slug) {
+		return c.json({ error: "Slug parameter is required" }, 400);
+	}
+
+	const rendered = await renderMarkdownFromDir(researchDir, slug);
+
+	if (!rendered) {
+		return c.json({ error: "Research article not found" }, 404);
+	}
+
+	return c.json({
+		slug: rendered.slug,
+		filename: rendered.filename,
+		contents: rendered.html,
+		filePath: rendered.filePath,
+		frontmatter: rendered.frontmatter,
+	});
+});
+
+export default app;

--- a/contents/research/wiki/_index.md
+++ b/contents/research/wiki/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Research Wiki Index"
+updated: "2026-04-05"
+---
+
+# Research Wiki
+
+## Categories
+
+### Sample
+
+- [Sample Topic](sample-topic) - A sample wiki article for development testing
+
+## Recently Updated
+
+| Article | Category | Status | Updated |
+|---------|----------|--------|---------|
+| [Sample Topic](sample-topic) | sample | draft | 2026-04-05 |

--- a/contents/research/wiki/sample-topic.md
+++ b/contents/research/wiki/sample-topic.md
@@ -1,0 +1,26 @@
+---
+title: "Sample Research Topic"
+category: "sample"
+tags: ["example", "test"]
+sources: ["raw/sample-source"]
+related: []
+created: "2026-04-05"
+updated: "2026-04-05"
+status: "draft"
+---
+
+# Sample Research Topic
+
+This is a sample wiki article for development and testing purposes.
+
+## Summary
+
+This article demonstrates the structure and frontmatter schema used by research wiki articles.
+
+## Key Concepts
+
+- **Category**: Articles are grouped by category for navigation
+- **Tags**: Fine-grained topic labels for filtering
+- **Sources**: References to raw source materials in the `raw/` directory
+- **Related**: Links to other wiki articles
+- **Status**: Article maturity level (draft, review, stable)

--- a/dev.config.ts
+++ b/dev.config.ts
@@ -1,3 +1,12 @@
+export type ContentSection = {
+	/** Directory path for this content section */
+	dir: string;
+	/** Route prefix (e.g., /posts, /research) */
+	routePrefix: string;
+	/** Display name for the section */
+	label?: string;
+};
+
 export type DevConfig = {
 	/** Directory path where markdown or mdx posts are stored */
 	postsDir: string;
@@ -8,6 +17,8 @@ export type DevConfig = {
 		/** Handle index files as directory or explicit path */
 		indexBehavior?: "directory" | "explicit";
 	};
+	/** Named content sections */
+	sections?: Record<string, ContentSection>;
 };
 
 const config: DevConfig = {
@@ -15,6 +26,18 @@ const config: DevConfig = {
 	routes: {
 		postsPrefix: "/posts",
 		indexBehavior: "directory",
+	},
+	sections: {
+		posts: {
+			dir: "contents/posts",
+			routePrefix: "/posts",
+			label: "Posts",
+		},
+		research: {
+			dir: "contents/research/wiki",
+			routePrefix: "/research",
+			label: "Research",
+		},
 	},
 };
 

--- a/lib/content/markdown.ts
+++ b/lib/content/markdown.ts
@@ -17,6 +17,9 @@ const postsDirectory = isAbsolute(configuredDir)
 	: resolve(hostCwd, configuredDir);
 const supportedMarkdownExtensions = [".md", ".mdx"] as const;
 
+const resolveDirectory = (dir: string): string =>
+	isAbsolute(dir) ? dir : resolve(hostCwd, dir);
+
 type PostMarkdownEntry = {
 	slug: string;
 	filePath: string;
@@ -24,6 +27,22 @@ type PostMarkdownEntry = {
 	extension: string;
 	title?: string;
 	private?: boolean;
+};
+
+export type MarkdownEntry = {
+	slug: string;
+	filePath: string;
+	filename: string;
+	extension: string;
+	title?: string;
+	private?: boolean;
+	category?: string;
+	tags?: string[];
+	status?: string;
+	related?: string[];
+	sources?: string[];
+	created?: string;
+	updated?: string;
 };
 
 const makeSlug = (filename: string) => {
@@ -215,6 +234,92 @@ const renderMarkdownString = async (markdown: string) => {
 export const renderMarkdownBySlug = async (slug: string) => {
 	const entry = resolveMarkdownFileBySlug(slug);
 	if (!entry) {
+		return;
+	}
+
+	const markdown = readFileSync(entry.filePath, { encoding: "utf8" });
+	const { html, frontmatter } = await renderMarkdownString(markdown);
+
+	return {
+		...entry,
+		markdown,
+		html,
+		frontmatter,
+	};
+};
+
+// --- Generic content directory functions ---
+
+const toStringArray = (
+	value: string | string[] | undefined,
+): string[] | undefined => {
+	if (Array.isArray(value)) return value;
+	if (typeof value === "string") return [value];
+	return undefined;
+};
+
+const toOptionalString = (
+	value: string | string[] | undefined,
+): string | undefined => {
+	if (typeof value === "string") return value;
+	return undefined;
+};
+
+export const getMarkdownEntries = (directory: string): MarkdownEntry[] => {
+	const dir = resolveDirectory(directory);
+	if (!existsSync(dir)) {
+		return [];
+	}
+
+	const items = readdirSync(dir, { withFileTypes: true });
+
+	return items
+		.filter((item) => {
+			if (item.isDirectory()) return false;
+			if (!isMarkdownFile(item.name)) return false;
+			// Exclude _index.md (reserved for wiki index)
+			if (item.name === "_index.md") return false;
+			return true;
+		})
+		.map((item) => {
+			const fullPath = join(dir, item.name);
+			const slug = makeSlug(item.name);
+			const extension =
+				supportedMarkdownExtensions.find((ext) => item.name.endsWith(ext)) ??
+				"";
+			const frontmatter = extractFrontmatterFromFile(fullPath);
+
+			const privateValue =
+				typeof frontmatter.private === "string"
+					? frontmatter.private === "true"
+					: undefined;
+
+			return {
+				filename: item.name,
+				slug,
+				filePath: fullPath,
+				extension,
+				title: toOptionalString(frontmatter.title),
+				private: privateValue,
+				category: toOptionalString(frontmatter.category),
+				tags: toStringArray(frontmatter.tags),
+				status: toOptionalString(frontmatter.status),
+				related: toStringArray(frontmatter.related),
+				sources: toStringArray(frontmatter.sources),
+				created: toOptionalString(frontmatter.created),
+				updated: toOptionalString(frontmatter.updated),
+			};
+		});
+};
+
+export const renderMarkdownFromDir = async (
+	directory: string,
+	slug: string,
+) => {
+	const entries = getMarkdownEntries(directory);
+	const entry = entries.find((e) => e.slug === slug);
+
+	if (!entry || !existsSync(entry.filePath)) {
 		return;
 	}
 

--- a/lib/openapi/schema.d.ts
+++ b/lib/openapi/schema.d.ts
@@ -4,259 +4,259 @@
  */
 
 export interface paths {
-    "/api/auth/token": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** @description Get a JWT token using an API key */
-        post: operations["postApiAuthToken"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** @description Refresh JWT token using existing valid token */
-        post: operations["postApiAuthRefresh"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/admin/users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Get list of all users (admin only) */
-        get: operations["getApiAdminUsers"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/deploy/deploy": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** @description Deploy the latest version of the application */
-        post: operations["postApiDeployDeploy"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/content/detail/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Get content details */
-        get: operations["getApiContentDetail:id"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+	"/api/auth/token": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/** @description Get a JWT token using an API key */
+		post: operations["postApiAuthToken"];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/api/auth/refresh": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/** @description Refresh JWT token using existing valid token */
+		post: operations["postApiAuthRefresh"];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/api/admin/users": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** @description Get list of all users (admin only) */
+		get: operations["getApiAdminUsers"];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/api/deploy/deploy": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/** @description Deploy the latest version of the application */
+		post: operations["postApiDeployDeploy"];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/api/content/detail/{id}": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** @description Get content details */
+		get: operations["getApiContentDetail:id"];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: never;
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+	schemas: never;
+	responses: never;
+	parameters: never;
+	requestBodies: never;
+	headers: never;
+	pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    postApiAuthToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response with JWT token */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        access_token: string;
-                        /** @constant */
-                        token_type: "Bearer";
-                        expires_in: number;
-                        client_name?: string;
-                    };
-                };
-            };
-        };
-    };
-    postApiAuthRefresh: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response with new JWT token */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        access_token: string;
-                        /** @constant */
-                        token_type: "Bearer";
-                        expires_in: number;
-                        client_name?: string;
-                    };
-                };
-            };
-        };
-    };
-    getApiAdminUsers: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response with list of users */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        users: {
-                            id: number;
-                            name: string;
-                            email: string;
-                        }[];
-                        client: string;
-                        timestamp: string;
-                    };
-                };
-            };
-        };
-    };
-    postApiDeployDeploy: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    owner: string;
-                    repo: string;
-                    event_type: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Successful response with deployment status */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        message: string;
-                        status: string;
-                    };
-                };
-            };
-            /** @description Failed to trigger deployment */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
-    };
-    "getApiContentDetail:id": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response with content details */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        title: string;
-                        content: string;
-                    };
-                };
-            };
-            /** @description Failed to get content details */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
-    };
+	postApiAuthToken: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response with JWT token */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": {
+						access_token: string;
+						/** @constant */
+						token_type: "Bearer";
+						expires_in: number;
+						client_name?: string;
+					};
+				};
+			};
+		};
+	};
+	postApiAuthRefresh: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response with new JWT token */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": {
+						access_token: string;
+						/** @constant */
+						token_type: "Bearer";
+						expires_in: number;
+						client_name?: string;
+					};
+				};
+			};
+		};
+	};
+	getApiAdminUsers: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response with list of users */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": {
+						users: {
+							id: number;
+							name: string;
+							email: string;
+						}[];
+						client: string;
+						timestamp: string;
+					};
+				};
+			};
+		};
+	};
+	postApiDeployDeploy: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: {
+			content: {
+				"application/json": {
+					owner: string;
+					repo: string;
+					event_type: string;
+				};
+			};
+		};
+		responses: {
+			/** @description Successful response with deployment status */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": {
+						message: string;
+						status: string;
+					};
+				};
+			};
+			/** @description Failed to trigger deployment */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": {
+						error: string;
+					};
+				};
+			};
+		};
+	};
+	"getApiContentDetail:id": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				id: string;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response with content details */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": {
+						title: string;
+						content: string;
+					};
+				};
+			};
+			/** @description Failed to get content details */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": {
+						error: string;
+					};
+				};
+			};
+		};
+	};
 }

--- a/lib/research/compiler.ts
+++ b/lib/research/compiler.ts
@@ -1,0 +1,112 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+
+const hostCwd = process.env.BLOG_RUNTIME_CWD ?? process.cwd();
+
+const resolveDir = (dir: string): string =>
+	isAbsolute(dir) ? dir : resolve(hostCwd, dir);
+
+export type RawSource = {
+	name: string;
+	path: string;
+	hasReadme: boolean;
+};
+
+export type RawSourceMetadata = {
+	name: string;
+	content: string;
+	fields: Record<string, string>;
+};
+
+/**
+ * List all raw source directories.
+ */
+export const listRawSources = (rawDir: string): RawSource[] => {
+	const dir = resolveDir(rawDir);
+	if (!existsSync(dir)) {
+		return [];
+	}
+
+	const items = readdirSync(dir, { withFileTypes: true });
+	return items
+		.filter((item) => item.isDirectory())
+		.map((item) => ({
+			name: item.name,
+			path: join(dir, item.name),
+			hasReadme: existsSync(join(dir, item.name, "README.md")),
+		}));
+};
+
+/**
+ * Read metadata from a raw source's README.md.
+ * Expects a simple key: value format in frontmatter.
+ */
+export const getRawSourceMetadata = (
+	sourceDir: string,
+): RawSourceMetadata | undefined => {
+	const dir = resolveDir(sourceDir);
+	const readmePath = join(dir, "README.md");
+
+	if (!existsSync(readmePath)) {
+		return undefined;
+	}
+
+	const content = readFileSync(readmePath, "utf8");
+
+	// Parse simple frontmatter
+	const fields: Record<string, string> = {};
+	const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+	if (fmMatch) {
+		for (const line of fmMatch[1].split("\n")) {
+			const match = line.match(/^([^:]+):\s*(.*)$/);
+			if (match) {
+				fields[match[1].trim()] = match[2].trim().replace(/^["']|["']$/g, "");
+			}
+		}
+	}
+
+	const name = dir.split("/").pop() ?? "";
+
+	return { name, content, fields };
+};
+
+/**
+ * Build a compilation context string from all files in a raw source directory.
+ * This aggregates text content suitable for passing to an LLM.
+ */
+export const buildCompilationContext = (sourceDir: string): string => {
+	const dir = resolveDir(sourceDir);
+	if (!existsSync(dir)) {
+		return "";
+	}
+
+	const textExtensions = [
+		".md",
+		".txt",
+		".json",
+		".csv",
+		".yaml",
+		".yml",
+		".toml",
+	];
+	const parts: string[] = [];
+
+	const items = readdirSync(dir, { withFileTypes: true });
+	for (const item of items) {
+		if (item.isDirectory()) continue;
+
+		const ext = item.name.slice(item.name.lastIndexOf(".")).toLowerCase();
+		if (!textExtensions.includes(ext)) continue;
+
+		const filePath = join(dir, item.name);
+		const stat = statSync(filePath);
+
+		// Skip files larger than 1MB
+		if (stat.size > 1_000_000) continue;
+
+		const content = readFileSync(filePath, "utf8");
+		parts.push(`--- FILE: ${item.name} ---\n${content}`);
+	}
+
+	return parts.join("\n\n");
+};

--- a/lib/research/index-generator.ts
+++ b/lib/research/index-generator.ts
@@ -1,0 +1,85 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+import type { MarkdownEntry } from "../content/markdown";
+import { getMarkdownEntries } from "../content/markdown";
+
+const hostCwd = process.env.BLOG_RUNTIME_CWD ?? process.cwd();
+
+const resolveDir = (dir: string): string =>
+	isAbsolute(dir) ? dir : resolve(hostCwd, dir);
+
+/**
+ * Generate the content for _index.md from all wiki entries.
+ */
+export const generateIndexContent = (wikiDir: string): string => {
+	const entries = getMarkdownEntries(wikiDir);
+
+	// Group by category
+	const grouped: Record<string, MarkdownEntry[]> = {};
+	for (const entry of entries) {
+		const cat = entry.category ?? "uncategorized";
+		if (!grouped[cat]) {
+			grouped[cat] = [];
+		}
+		grouped[cat].push(entry);
+	}
+
+	const lines: string[] = [
+		"---",
+		`title: "Research Wiki Index"`,
+		`updated: "${new Date().toISOString().slice(0, 10)}"`,
+		"---",
+		"",
+		"# Research Wiki",
+		"",
+		"## Categories",
+		"",
+	];
+
+	for (const [category, catEntries] of Object.entries(grouped).sort()) {
+		lines.push(`### ${category.charAt(0).toUpperCase() + category.slice(1)}`);
+		lines.push("");
+		for (const entry of catEntries) {
+			const statusBadge = entry.status ? ` (${entry.status})` : "";
+			lines.push(
+				`- [${entry.title ?? entry.slug}](${entry.slug})${statusBadge}`,
+			);
+		}
+		lines.push("");
+	}
+
+	// Recently updated section
+	const sorted = [...entries]
+		.filter((e) => e.updated)
+		.sort((a, b) => (b.updated ?? "").localeCompare(a.updated ?? ""));
+	const recent = sorted.slice(0, 10);
+
+	if (recent.length > 0) {
+		lines.push("## Recently Updated");
+		lines.push("");
+		lines.push("| Article | Category | Status | Updated |");
+		lines.push("|---------|----------|--------|---------|");
+		for (const entry of recent) {
+			lines.push(
+				`| [${entry.title ?? entry.slug}](${entry.slug}) | ${entry.category ?? "-"} | ${entry.status ?? "-"} | ${entry.updated ?? "-"} |`,
+			);
+		}
+		lines.push("");
+	}
+
+	return lines.join("\n");
+};
+
+/**
+ * Write the generated index to _index.md in the wiki directory.
+ */
+export const writeWikiIndex = (wikiDir: string): void => {
+	const dir = resolveDir(wikiDir);
+	if (!existsSync(dir)) {
+		throw new Error(`Wiki directory does not exist: ${dir}`);
+	}
+
+	const content = generateIndexContent(wikiDir);
+	const indexPath = join(dir, "_index.md");
+	writeFileSync(indexPath, content, "utf8");
+};

--- a/lib/research/linter.ts
+++ b/lib/research/linter.ts
@@ -1,0 +1,142 @@
+import { existsSync, readdirSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import type { MarkdownEntry } from "../content/markdown";
+import { getMarkdownEntries } from "../content/markdown";
+
+const hostCwd = process.env.BLOG_RUNTIME_CWD ?? process.cwd();
+
+const resolveDir = (dir: string): string =>
+	isAbsolute(dir) ? dir : resolve(hostCwd, dir);
+
+export type LintSeverity = "error" | "warning" | "info";
+
+export type LintResult = {
+	severity: LintSeverity;
+	rule: string;
+	message: string;
+	file?: string;
+};
+
+const requiredFrontmatterFields = [
+	"title",
+	"category",
+	"status",
+	"created",
+	"updated",
+];
+
+/**
+ * Lint the research wiki for common issues.
+ */
+export const lintWiki = (wikiDir: string, rawDir?: string): LintResult[] => {
+	const results: LintResult[] = [];
+	const entries = getMarkdownEntries(wikiDir);
+	const slugSet = new Set(entries.map((e) => e.slug));
+
+	for (const entry of entries) {
+		// Check required frontmatter fields
+		for (const field of requiredFrontmatterFields) {
+			const value = entry[field as keyof MarkdownEntry];
+			if (value === undefined || value === "") {
+				results.push({
+					severity: "warning",
+					rule: "missing-frontmatter",
+					message: `Missing required frontmatter field: ${field}`,
+					file: entry.filename,
+				});
+			}
+		}
+
+		// Check for broken related links
+		if (entry.related) {
+			for (const rel of entry.related) {
+				if (!slugSet.has(rel)) {
+					results.push({
+						severity: "error",
+						rule: "broken-link",
+						message: `Related article not found: ${rel}`,
+						file: entry.filename,
+					});
+				}
+			}
+		}
+
+		// Check backlink symmetry
+		if (entry.related) {
+			for (const rel of entry.related) {
+				const target = entries.find((e) => e.slug === rel);
+				if (target && !target.related?.includes(entry.slug)) {
+					results.push({
+						severity: "info",
+						rule: "missing-backlink",
+						message: `${entry.slug} links to ${rel}, but ${rel} does not link back`,
+						file: entry.filename,
+					});
+				}
+			}
+		}
+	}
+
+	// Check for orphan articles (not linked from any other article)
+	for (const entry of entries) {
+		const isLinked = entries.some(
+			(other) =>
+				other.slug !== entry.slug && other.related?.includes(entry.slug),
+		);
+		if (!isLinked && entries.length > 1) {
+			results.push({
+				severity: "info",
+				rule: "orphan-article",
+				message: `Article is not referenced by any other article`,
+				file: entry.filename,
+			});
+		}
+	}
+
+	// Check raw sources with no corresponding wiki article
+	if (rawDir) {
+		const resolvedRawDir = resolveDir(rawDir);
+		if (existsSync(resolvedRawDir)) {
+			const rawItems = readdirSync(resolvedRawDir, { withFileTypes: true });
+			const rawDirs = rawItems
+				.filter((item) => item.isDirectory())
+				.map((item) => item.name);
+
+			const allSources = new Set(entries.flatMap((e) => e.sources ?? []));
+
+			for (const rawDirName of rawDirs) {
+				const sourceRef = `raw/${rawDirName}`;
+				if (!allSources.has(sourceRef)) {
+					results.push({
+						severity: "warning",
+						rule: "unlinked-source",
+						message: `Raw source directory has no corresponding wiki article: ${rawDirName}`,
+						file: rawDirName,
+					});
+				}
+			}
+		}
+	}
+
+	// Check for stale drafts (articles with status "draft" and old updated date)
+	const thirtyDaysAgo = new Date();
+	thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+	const thirtyDaysAgoStr = thirtyDaysAgo.toISOString().slice(0, 10);
+
+	for (const entry of entries) {
+		if (
+			entry.status === "draft" &&
+			entry.updated &&
+			entry.updated < thirtyDaysAgoStr
+		) {
+			results.push({
+				severity: "info",
+				rule: "stale-draft",
+				message: `Draft article not updated in 30+ days (last: ${entry.updated})`,
+				file: entry.filename,
+			});
+		}
+	}
+
+	return results;
+};


### PR DESCRIPTION
## Summary

- Add a research content section alongside existing posts, enabling an LLM-powered personal knowledge base with raw source ingestion, wiki compilation, linting, and Q&A capabilities
- Extend `DevConfig` with `sections` (`ContentSection` type) for multi-content support
- Generalize markdown parser with `getMarkdownEntries()` and `renderMarkdownFromDir()` to support arbitrary content directories
- Add research web routes: listing (grouped by category), detail (with status/tags/related/sources), SSG middleware, and JSON API endpoint
- Add LLM agent tools: wiki index generator, wiki linter, raw-to-wiki compiler helpers
- Add `CLAUDE.md` with agent instructions for wiki operations

## Test plan

- [ ] `pnpm dev` でサーバー起動、`/research` にアクセスして一覧表示確認
- [ ] `/research/sample-topic` でサンプル記事の詳細表示確認
- [ ] 既存の `/posts` ルートが正常に動作することを確認（後方互換性）
- [ ] `pnpm check` でlint/formatエラーがないことを確認
- [ ] `pnpm build` でSSGビルドが成功することを確認

https://claude.ai/code/session_015QbYmPeo7hBUrspEdMkC6h